### PR TITLE
Catch up with upstream + rename default branch to main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Test Suite
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ "8.0", 8.1 ]
+        php: [ "8.0", "8.1", "8.2", "8.3", "8.4", "8.5" ]
     name: "PHP ${{ matrix.php }} Unit Test"
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ oauth2-server-httpfoundation-bridge
 
 A bridge to [HttpFoundation](https://github.com/symfony/httpfoundation) for [oauth2-server-php](https://github.com/reb3r/oauth2-server-php).
 
-[![Build Status](https://travis-ci.com/reb3r/oauth2-server-httpfoundation-bridge.svg?branch=master)](https://travis-ci.com/reb3r/oauth2-server-httpfoundation-bridge)
+[![Build Status](https://travis-ci.com/reb3r/oauth2-server-httpfoundation-bridge.svg?branch=main)](https://travis-ci.com/reb3r/oauth2-server-httpfoundation-bridge)
 
 `oauth2-server-httpfoundation-bridge` is a wrapper for [oauth2-server-php](https://github.com/bshaffer/oauth2-server-php)
 which returns `Symfony\Component\HttpFoundation\Response` instead of `OAuth2\Response`, and uses `Symfony\Component\HttpFoundation\Request` instead of `OAuth2\Request`.

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	"homepage": "http://github.com/bshaffer/oauth2-server-httpfoundation-bridge",
 	"require": {
 		"php": "^8.0",
-		"symfony/http-foundation": "^5.4||^6.0||^7.0",
+		"symfony/http-foundation": "^5.4||^6.0||^7.0||^8.0",
 		"reb3r/oauth2-server-php": ">=0.9"
 	},
 	"require-dev": {


### PR DESCRIPTION
## Summary

- Catch up with upstream `bshaffer/oauth2-server-httpfoundation-bridge#47`: allow `symfony/http-foundation ^8.0` in `composer.json`
- Extend CI PHP test matrix from `8.0, 8.1` to `8.0 – 8.5`
- Rename default branch references from `master` to `main` (workflow trigger + README badge)

## Test plan

- [ ] CI green on the new PHP matrix
- [ ] `composer require symfony/http-foundation:^8.0` resolves without conflicts
- [ ] After merge: confirm workflow runs on push to `main`